### PR TITLE
Add clojure.lang.BigInt support.

### DIFF
--- a/src/sirius/core.clj
+++ b/src/sirius/core.clj
@@ -1,7 +1,8 @@
 (ns sirius.core
   (:require [clojure.java.io :refer [resource]]
             [clojure.string :refer [split]])
-  (:import [java.math BigInteger]))
+  (:import [java.math BigInteger]
+           [clojure.lang BigInt]))
 
 (set! *warn-on-reflection* true)
 
@@ -22,16 +23,19 @@
 
 (extend-protocol UnicodeNameLookup
   (Class/forName "[B")
-  (name-of [b] (-> ^bytes b (BigInteger.) (name-table)))
+  (name-of [b] (-> ^bytes b BigInteger. name-table))
 
   Character
   (name-of [c] (name-table (int c)))
 
   String
-  (name-of [s] (-> s (first) (int) (name-table)))
+  (name-of [s] (-> s first int name-table))
 
   BigInteger
-  (name-of [bi] (-> ^BigInteger bi (.longValue) (name-table)))
+  (name-of [bi] (-> ^BigInteger bi .longValue name-table))
+
+  BigInt
+  (name-of [bi] (-> ^BigInt bi .longValue name-table))
 
   Integer
   Long

--- a/test/sirius/core_test.clj
+++ b/test/sirius/core_test.clj
@@ -14,7 +14,9 @@
     (testing "Using integer (long)"
       (is (= (name-of 9806) name)))
     (testing "Using BigInteger"
-      (is (= (name-of (BigInteger. "264E" 16)) name)))))
+      (is (= (name-of (BigInteger. "264E" 16)) name)))
+    (testing "Using BigInt"
+      (is (= (name-of 9806N) name)))))
 
 (deftest control-char-test
   (testing "<control> characters get names too"


### PR DESCRIPTION
BigInts are pretty common in Clojure.  They can be made with a 'N' suffix, and any normal calculation may coerce to a BigInt eg `(*' 2 Long/MAX_VALUE)`.  They are a bit more performant.  This pull request adds support for them.

It also removes several unnecessary parens in core.